### PR TITLE
Switched out useCustomMonaco for MonacoProvider

### DIFF
--- a/components/monaco-provider.tsx
+++ b/components/monaco-provider.tsx
@@ -1,0 +1,58 @@
+import { MonacoProvider } from "use-monaco"
+import useTheme from "hooks/useTheme"
+
+const themes = {
+  light: {
+    base: "vs",
+    inherit: true,
+    rules: [],
+    colors: {
+      "editor.lineHighlightBorder": "#77777700",
+      "editor.lineHighlightBackground": "#77777711",
+      "editorBracketMatch.border": "#00000000",
+      "editorBracketMatch.background": "#00000022",
+      "editorIndentGuide.background": "#ffffff00",
+    },
+  },
+  dark: {
+    base: "vs-dark",
+    inherit: true,
+    rules: [],
+    colors: {
+      "editor.lineHighlightBorder": "#777777ff",
+      "editor.lineHighlightBackground": "#77777717",
+      "editorBracketMatch.border": "#ffffff00",
+      "editorBracketMatch.background": "#ffffff22",
+      "editorIndentGuide.background": "#00000000",
+    },
+  },
+}
+
+export function CustomMonacoProvider({ children }) {
+  const { theme } = useTheme()
+  return (
+    <MonacoProvider
+      theme={theme}
+      plugins={{
+        theme: {
+          themes: themes,
+        },
+        typings: true,
+        prettier: ["javascript", "typescript", "json"],
+      }}
+      onLoad={(monaco) => {
+        if (monaco) {
+          monaco.languages.typescript?.loadTypes("state-designer", "1.3.35")
+          monaco.languages.typescript?.exposeGlobal(
+            "state-designer",
+            "useStateDesigner",
+            "useStateDesigner",
+          )
+          return null
+        }
+      }}
+    >
+      {children}
+    </MonacoProvider>
+  )
+}

--- a/components/project/code.tsx
+++ b/components/project/code.tsx
@@ -5,7 +5,7 @@ import parser from "prettier/parser-typescript"
 import debounce from "lodash/debounce"
 import { styled, IconButton, TabButton } from "components/theme"
 import { Save, RefreshCcw, AlertCircle } from "react-feather"
-import { useMonaco, useEditor, useFile } from "use-monaco"
+import { useMonaco, useEditor, useFile, useMonacoContext } from "use-monaco"
 import themes from "use-monaco/themes"
 import { CodeEditorTab } from "types"
 import { DragHandleHorizontal } from "./drag-handles"
@@ -17,7 +17,6 @@ import { codeValidators, codeFormatValidators } from "lib/eval"
 import { Highlights } from "components/project/highlights"
 import useMotionResizeObserver from "use-motion-resize-observer"
 import useTheme from "hooks/useTheme"
-import useCustomMonaco from "hooks/useCustomMonaco"
 import useCustomEditor from "hooks/useCustomEditor"
 
 const EDITOR_TABS = ["state", "view", "static"]
@@ -330,31 +329,24 @@ export default function CodePanel({ uid, pid, oid }: CodePanelProps) {
   // Local state
   const local = useStateDesigner(codePanelState)
 
-  const { monaco } = useCustomMonaco("typescript")
-
   const stateModel = useFile({
-    path: "state.js",
-    monaco,
+    path: "state.ts",
     defaultContents: "",
-    language: "typescript",
   })
 
   const viewModel = useFile({
-    path: "view.js",
-    monaco,
+    path: "view.tsx",
     defaultContents: "",
-    language: "typescript",
   })
 
   const staticModel = useFile({
-    path: "static.js",
-    monaco,
+    path: "static.ts",
     defaultContents: "",
-    language: "typescript",
   })
 
+  const { monaco } = useMonacoContext()
+
   const { editor, containerRef } = useCustomEditor(
-    monaco,
     stateModel,
     oid !== uid,
     false,

--- a/components/project/details.tsx
+++ b/components/project/details.tsx
@@ -4,7 +4,6 @@ import { animate } from "framer-motion"
 import { useStateDesigner } from "@state-designer/react"
 import { useFile } from "use-monaco"
 import useCustomEditor from "hooks/useCustomEditor"
-import useCustomMonaco from "hooks/useCustomMonaco"
 import {
   styled,
   IconButton,
@@ -39,24 +38,19 @@ export default function Details({}: DetailsProps) {
     view: null,
   })
 
-  const { monaco } = useCustomMonaco("json")
-
   const dataModel = useFile({
     path: "data.json",
-    monaco,
     defaultContents: JSON.stringify(captive.data, null, 2),
-    language: "json",
+    // language: "json",
   })
 
   const valuesModel = useFile({
     path: "values.json",
-    monaco,
     defaultContents: JSON.stringify(captive.values, null, 2),
-    language: "json",
+    // language: "json",
   })
 
   const { editor, containerRef } = useCustomEditor(
-    monaco,
     dataModel,
     true,
     isWrapped,

--- a/hooks/useCustomEditor.tsx
+++ b/hooks/useCustomEditor.tsx
@@ -6,16 +6,12 @@ import debounce from "lodash/debounce"
 import useMotionResizeObserver from "use-motion-resize-observer"
 
 export default function useCustomEditor(
-  monaco: any,
   model: any,
   readOnly: boolean,
   wrap: boolean,
   onChange: (code: string) => void,
 ) {
-  const { theme } = useTheme()
-
   const { editor, containerRef } = useEditor({
-    monaco,
     model,
     options: {
       fontSize: 13,
@@ -31,6 +27,7 @@ export default function useCustomEditor(
       lineNumbers: "off",
       scrollBeyondLastLine: false,
       wordWrap: wrap ? "on" : "off",
+      readOnly,
       scrollbar: {
         verticalScrollbarSize: 0,
         verticalSliderSize: 8,
@@ -41,9 +38,9 @@ export default function useCustomEditor(
       cursorWidth: 3,
     },
     editorDidMount: (editor) => {
-      editor.updateOptions({
-        readOnly,
-      })
+      // editor.updateOptions({
+      //   readOnly,
+      // })
 
       editor.onKeyDown((e) => {
         if (e.metaKey) {
@@ -58,10 +55,10 @@ export default function useCustomEditor(
     onChange,
   })
 
-  React.useEffect(() => {
-    if (!monaco) return
-    monaco.editor.setTheme(theme)
-  }, [monaco, editor, theme])
+  // React.useEffect(() => {
+  //   if (!monaco) return
+  //   monaco.editor.setTheme(theme)
+  // }, [monaco, editor, theme])
 
   // Resizing
   const resizeEditor = React.useCallback(
@@ -75,21 +72,21 @@ export default function useCustomEditor(
     onResize: resizeEditor,
   })
 
-  React.useEffect(() => {
-    if (editor) {
-      editor.updateOptions({
-        readOnly,
-      })
-    }
-  }, [editor, readOnly])
+  // React.useEffect(() => {
+  //   if (editor) {
+  //     editor.updateOptions({
+  //       readOnly,
+  //     })
+  //   }
+  // }, [editor, readOnly])
 
-  React.useEffect(() => {
-    if (editor) {
-      editor.updateOptions({
-        wordWrap: wrap ? "on" : "off",
-      })
-    }
-  }, [editor, wrap])
+  // React.useEffect(() => {
+  //   if (editor) {
+  //     editor.updateOptions({
+  //       wordWrap: wrap ? "on" : "off",
+  //     })
+  //   }
+  // }, [editor, wrap])
 
   return { editor, containerRef: mergeRefs([resizeRef, containerRef]) }
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,12 +1,14 @@
 import "../styles/globals.css"
 import Toast from "../components/toast"
+import React from "react"
+import { CustomMonacoProvider } from "../components/monaco-provider"
 
 function MyApp({ Component, pageProps }) {
   return (
-    <>
+    <CustomMonacoProvider>
       <Component {...pageProps} />
       <Toast />
-    </>
+    </CustomMonacoProvider>
   )
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,7 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx"
-, "pages/_app.js"  ],
+, "pages/_app.tsx"  ],
   "exclude": [
     "node_modules"
   ]


### PR DESCRIPTION
Switched out useCustomMonaco for MonacoProvider that wraps the App. monaco is loaded but nothing is really initialized till the editors are loaded. Don't need custom code for prettier formatting (some more fixes coming soon), or theming, all built in), attempted typing, need to debug it

`useFile` and `useEditor` pick up monaco from context if they are not input. Also changed the file paths to .ts and .tsx so that the typscript worker can interpret them correctly. Might not be the desired behaviour but I was doing it to test the typings.

the onLoad bug will be fixed in a patch version, the current changes dont include it