### PR TITLE
Fixed some bugs and introduced typings in the use-monaco usage

### DIFF
--- a/components/project/code-panel.tsx
+++ b/components/project/code-panel.tsx
@@ -2,7 +2,7 @@
 import * as React from "react"
 import { styled, IconButton, TabButton } from "components/theme"
 import { Save, RefreshCcw, AlertCircle } from "react-feather"
-import { useFile, useMonacoContext } from "use-monaco"
+import { useTextModel, useMonacoContext } from "use-monaco"
 import { CodeEditorTab } from "types"
 import { DragHandleHorizontal } from "./drag-handles"
 import { CODE_COL_WIDTH } from "./index"
@@ -24,21 +24,21 @@ export default function CodePanel({ uid, pid, oid }: CodePanelProps) {
 
   const { monaco } = useMonacoContext()
 
-  const stateModel = useFile({
+  const stateModel = useTextModel({
     path: "state.tsx",
     monaco,
     defaultContents: "",
-    language: "javascript",
+    language: "typescript",
   })
 
-  const viewModel = useFile({
+  const viewModel = useTextModel({
     path: "view.tsx",
     monaco,
     defaultContents: "",
-    language: "javascript",
+    language: "typescript",
   })
 
-  const staticModel = useFile({
+  const staticModel = useTextModel({
     path: "static.tsx",
     monaco,
     defaultContents: "",

--- a/components/project/details-panel.tsx
+++ b/components/project/details-panel.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { animate } from "framer-motion"
 import { useStateDesigner } from "@state-designer/react"
-import { useFile, useMonacoContext } from "use-monaco"
+import { useTextModel, useMonacoContext } from "use-monaco"
 import useCustomEditor from "hooks/useCustomEditor"
 import {
   styled,
@@ -39,14 +39,14 @@ export default function Details({}: DetailsProps) {
 
   const { monaco } = useMonacoContext()
 
-  const dataModel = useFile({
+  const dataModel = useTextModel({
     path: "data.json",
     monaco,
     defaultContents: JSON.stringify(captive.data, null, 2),
     language: "json",
   })
 
-  const valuesModel = useFile({
+  const valuesModel = useTextModel({
     path: "values.json",
     monaco,
     defaultContents: JSON.stringify(captive.values, null, 2),

--- a/hooks/useCustomEditor.tsx
+++ b/hooks/useCustomEditor.tsx
@@ -1,7 +1,6 @@
 import * as React from "react"
 import { useEditor } from "use-monaco"
 import mergeRefs from "react-merge-refs"
-import useTheme from "./useTheme"
 import debounce from "lodash/debounce"
 import useMotionResizeObserver from "use-motion-resize-observer"
 
@@ -13,8 +12,6 @@ export default function useCustomEditor(
   onMount?: (editor: any) => void,
   onChange?: (code: string) => void,
 ) {
-  const { theme } = useTheme()
-
   const { editor, containerRef } = useEditor({
     monaco,
     model,
@@ -28,6 +25,7 @@ export default function useCustomEditor(
       smoothScrolling: true,
       lineDecorationsWidth: 4,
       fontLigatures: true,
+      readOnly,
       cursorBlinking: "smooth",
       lineNumbers: "off",
       scrollBeyondLastLine: false,
@@ -41,7 +39,7 @@ export default function useCustomEditor(
       renderLineHighlight: "all",
       cursorWidth: 3,
     },
-    editorDidMount: (editor) => {
+    onEditorDidMount: (editor) => {
       editor.updateOptions({
         readOnly,
       })
@@ -63,11 +61,6 @@ export default function useCustomEditor(
     },
   })
 
-  React.useEffect(() => {
-    if (!monaco) return
-    monaco.editor.setTheme(theme)
-  }, [monaco, editor, theme])
-
   // Resizing
   const resizeEditor = React.useCallback(
     debounce(() => {
@@ -79,22 +72,6 @@ export default function useCustomEditor(
   const { ref: resizeRef } = useMotionResizeObserver<HTMLDivElement>({
     onResize: resizeEditor,
   })
-
-  React.useEffect(() => {
-    if (editor) {
-      editor.updateOptions({
-        readOnly,
-      })
-    }
-  }, [editor, readOnly])
-
-  React.useEffect(() => {
-    if (editor) {
-      editor.updateOptions({
-        wordWrap: wrap ? "on" : "off",
-      })
-    }
-  }, [editor, wrap])
 
   return { editor, containerRef: mergeRefs([resizeRef, containerRef]) }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-live": "^2.2.3",
     "react-merge-refs": "^1.1.0",
     "react-use-gesture": "^9.0.0-beta.11",
-    "use-monaco": "^0.0.34",
+    "use-monaco": "^0.0.35",
     "use-motion-resize-observer": "^2.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1442,7 +1442,7 @@ color-string@^1.5.4:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
-color@^3.1.2:
+color@^3.1.2, color@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/color/-/color-3.1.3.tgz#ca67fb4e7b97d611dcde39eceed422067d91596e"
   integrity sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==
@@ -1459,6 +1459,11 @@ commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+commander@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
+  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -1793,6 +1798,11 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
@@ -1953,6 +1963,14 @@ domutils@^2.0.0:
     dom-serializer "^1.0.1"
     domelementtype "^2.0.1"
     domhandler "^4.0.0"
+
+dot-object@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/dot-object/-/dot-object-2.1.4.tgz#c6c54e9fca510b4d0ea4d65acf33726963843b5f"
+  integrity sha512-7FXnyyCLFawNYJ+NhkqyP9Wd2yzuo+7n9pGiYpkmXCTYa8Ci2U0eUNDVg5OuO5Pm6aFXI2SWN8/N/w7SJWu1WA==
+  dependencies:
+    commander "^4.0.0"
+    glob "^7.1.5"
 
 dot-prop@^5.2.0:
   version "5.3.0"
@@ -2541,7 +2559,7 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@^7.1.3, glob@^7.1.4:
+glob@^7.1.3, glob@^7.1.4, glob@^7.1.5:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -5393,12 +5411,16 @@ use-deep-compare-effect@^1.3.1:
     "@types/react" "^17.0.0"
     dequal "^2.0.2"
 
-use-monaco@^0.0.34:
-  version "0.0.34"
-  resolved "https://registry.yarnpkg.com/use-monaco/-/use-monaco-0.0.34.tgz#5eb3e7cd156541717ac57400e8beb8a7321f90d8"
-  integrity sha512-my7YXrCoxZVehjVYDsbUhKV6pAYDy/uYPPNCYKsqXpOmhV+fdewfgfgfCCIarPpqs7ywRX5O+AT51xm+sSCFUQ==
+use-monaco@^0.0.35:
+  version "0.0.35"
+  resolved "https://registry.yarnpkg.com/use-monaco/-/use-monaco-0.0.35.tgz#6a664aa3cacdbe8c912535156959cdf8834fcb64"
+  integrity sha512-pYvrdI81aFNlTcSUABOoRoST2GrDqgBWLGhhypYNKKLf12SY9nW0FZeXtOlx/UTs7k/ASHtY2ZomdqpjEqSX9Q==
   dependencies:
+    color "^3.1.3"
     create-hook-context "^1.0.0"
+    deepmerge "^4.2.2"
+    dequal "^2.0.2"
+    dot-object "^2.1.4"
     graphql-language-service "^3.0.4"
     graphql-language-service-types "^1.6.3"
     monaco-editor "^0.21.2"


### PR DESCRIPTION
Fixes some use cases that are directly covered by use-monaco, 

- MonacoProvider reacts to the  theme prop to set the theme itself, also editor itself should not be setting theme since Monaco only allows one theme globally, 
- the prettier plugin now handles custom prettier options and works with your current setup, fixed the bugs that you might have had.. 
- typings now working for createState, useStateDesigner, React, etc... and the eagerModelSync, compiler options, etc. are all handled by the typings plugin. 
- Also renamed useFile to useTextModel to not deviate from monaco naming convention